### PR TITLE
feat(day hiding): add support for hiding the days in a range

### DIFF
--- a/src/relative-range.js
+++ b/src/relative-range.js
@@ -8,6 +8,7 @@ type RangeSchemaTypeEnum = typeof Date | typeof String | typeof Number | typeof 
 
 export type FormatStaticOptionsType = {
   attemptYearHiding?: boolean;
+  attemptDayHiding?: boolean;
 }
 
 function isDateType(Type: RangeSchemaTypeEnum): boolean {

--- a/tests/format.spec.js
+++ b/tests/format.spec.js
@@ -71,6 +71,70 @@ describe('RelativeRange#format', function () {
       de: '1. Januar',
     },
   }, {
+    range: range.previous(1, 'month'),
+    format: 'LL',
+    locales: {
+      en: 'December, 2999',
+      nl: 'december 2999',
+      de: 'Dezember 2999',
+      es: 'diciembre de 2999',
+    },
+    options: {
+      attemptDayHiding: true,
+      attemptYearHiding: false,
+    },
+  }, {
+    range: range.next(1, 'month'),
+    format: 'LL',
+    locales: {
+      en: 'February',
+      nl: 'februari',
+      de: 'Februar',
+    },
+    options: {
+      attemptDayHiding: true,
+      attemptYearHiding: true,
+    },
+  }, {
+    range: range.next(2, 'month'),
+    format: 'LL',
+    locales: {
+      en: 'February - March',
+      nl: 'februari t/m maart',
+      de: 'Februar - März',
+      es: 'febrero al marzo',
+    },
+    options: {
+      attemptDayHiding: true,
+      attemptYearHiding: true,
+    },
+  }, {
+    range: range.next(2, 'month'),
+    format: 'll',
+    locales: {
+      en: 'Feb - Mar',
+      nl: 'feb. t/m mrt.',
+      de: 'Feb. - März',
+      es: 'feb. al mar.',
+    },
+    options: {
+      attemptDayHiding: true,
+      attemptYearHiding: true,
+    },
+  }, {
+    range: range.next(3, 'month'),
+    format: 'LL',
+    locales: {
+      en: 'February, 3000 - April, 3000',
+      nl: 'februari 3000 t/m april 3000',
+      de: 'Februar 3000 - April 3000',
+      es: 'febrero de 3000 al abril de 3000',
+    },
+    options: {
+      attemptDayHiding: true,
+      attemptYearHiding: false,
+    },
+  }, {
     range: range.previous(24, 'month'),
     format: 'LL',
     locales: {


### PR DESCRIPTION
When dealing with whole months it’s not always required to show all days in that month. `December, 2018` is just as clear, or even more clear than `December 1 - 31, 2018`. With the `attemptDayHiding` option in static range formatting you can now try this functionality.